### PR TITLE
Update App.js

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -115,11 +115,11 @@ class App extends Component {
     this.state.erc20.methods
       .approve(this.state.tokenFarm._address, amount)
       .send({ from: this.state.account })
-      .on("transactionHash", (hash) => {
+      .on("receipt", (hash) => {
         this.state.tokenFarm.methods
           .stakeTokens(amount, tokenAddress)
           .send({ from: this.state.account })
-          .on("transactionHash", (hash) => {
+          .on("receipt", (hash) => {
             this.setState({ loading: false })
           })
       })


### PR DESCRIPTION
PR following the discussion here: https://github.com/PatrickAlphaC/chainlink_defi/issues/6#issue-1106073597
Changing both `transactionHash` -> `receipt`:
1) first one for UI reasons... otherwise user sees "this transaction is expected to fail" and might get scared to click "I will try anyways" (this is because the approve hasn't been accepted yet so metamask doesn't know about it..
2) second one because of the bug explained here: https://github.com/MetaMask/metamask-extension/issues/13197#issuecomment-1015697640